### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "3.1.1"
+util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Pin `com.enonic.lib:lib-util` to the next-major SNAPSHOT published from master to align with the XP 8 upgrade (xpVersion `8.0.0-B4`). We are not releasing the lib yet; this consumes the SNAPSHOT directly from the Enonic dev repo.

## Libs bumped

| Lib | Before | After |
| --- | --- | --- |
| `com.enonic.lib:lib-util` | `3.1.1` (release) | `4.0.0-SNAPSHOT` (dev repo) |

The new pin is a SNAPSHOT and resolves from the Enonic dev/snapshot Maven repo.

## Snapshot repo

Already declared in `build.gradle` via `xp.enonicRepo('dev')`. No change was needed.

## Excludes audit

None — `build.gradle` has no `exclude` clauses on any dependency, so there was nothing to remove or re-evaluate.

## Verification

- `./gradlew clean build` — green.
- `./gradlew dependencies --configuration runtimeClasspath` confirms `com.enonic.lib:lib-util:4.0.0-SNAPSHOT` resolves.
- Runtime verification (deploying into a running XP server) was not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)