### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "1.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "1.x", "latest": true },
+    { "label": "next", "checkout": "master" }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ vendorName=Enonic AS
 vendorUrl=https://enonic.com
 
 xpVersion=8.0.0-B4
-version=1.2.1-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bump master `version` from `1.2.1-SNAPSHOT` to `2.0.0-SNAPSHOT` to start the XP 8 / 2.x line.
- Wire `enonic-gradle.yml` to recognize both `master` and `1.x` as release branches.
- Add `1.x` to `enonic-docgen.yml`'s push triggers.
- Add `docs/versions.json` declaring `1.x` as the stable docs branch and `master` as next.

The `1.x` maintenance branch is created separately at SHA `1edc95f23d376706c8d9182975a9a8f4459cb877` (the post-`v1.2.0` "Updated to next SNAPSHOT version" commit), so its `gradle.properties` stays at `1.2.1-SNAPSHOT`. A companion PR against `1.x` mirrors the `releaseBranch:` block so pushes there are recognized as release-branch builds.

## Test plan

- [ ] CI green on this PR (`Gradle Build`)
- [ ] After merge: `./gradlew clean build` from master succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)