### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- On the `1.x` maintenance branch, add a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x`.
- This is required so pushes to `1.x` are recognized as release-branch builds — the `enonic/release-tools` action reads `releaseBranch:` from the branch's own workflow file.
- Companion of #48, which bumps `master` to `2.0.0-SNAPSHOT` and applies the same workflow change there. The `1.x` branch's `gradle.properties` stays at `1.2.1-SNAPSHOT` (the post-`v1.2.0` SNAPSHOT) — no version bump here.

## Test plan

- [ ] CI green on this PR (`Gradle Build`)
- [ ] After merge: a CI run on `1.x` classifies it as a release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)