### PR TITLE
Drop lib-util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     include xplibs.admin
 
     include libs.lib.thymeleaf
-    include libs.lib.util
 
     include 'com.google.auth:google-auth-library-oauth2-http:1.47.0'
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,5 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
-lib-util = { module = "com.enonic.lib:lib-util", version.ref = "util" }

--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -1,7 +1,6 @@
 const libs = {
     portal: require('/lib/xp/portal'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 
 const view = resolve('add-script.html');
@@ -26,7 +25,7 @@ exports.responseProcessor = function (req, res) {
         const metadata = libs.thymeleaf.render(view, params);
 
         // Force arrays since single values will be return as string instead of array
-        res.pageContributions.headEnd = libs.util.data.forceArray(res.pageContributions.headEnd);
+        res.pageContributions.headEnd = Array.isArray(res.pageContributions.headEnd) ? res.pageContributions.headEnd : [res.pageContributions.headEnd];
         res.pageContributions.headEnd.push(metadata);
 
         const triggerParams = {
@@ -39,7 +38,7 @@ exports.responseProcessor = function (req, res) {
         };
         const triggerHtml = libs.thymeleaf.render(triggerView, triggerParams);
 
-        res.pageContributions.bodyEnd = libs.util.data.forceArray(res.pageContributions.bodyEnd);
+        res.pageContributions.bodyEnd = Array.isArray(res.pageContributions.bodyEnd) ? res.pageContributions.bodyEnd : [res.pageContributions.bodyEnd];
         res.pageContributions.bodyEnd.push(triggerHtml);
     }
 


### PR DESCRIPTION
## Summary
- Inline the only `lib-util` call (`util.data.forceArray`) at its two call sites in `src/main/resources/cms/processors/add-script.js` as `Array.isArray(x) ? x : [x]` — byte-equivalent to the lib-util implementation.
- Remove the `util: require('/lib/util')` import.
- Drop `lib-util` from `build.gradle` and `gradle/libs.versions.toml` (both `[versions]` and `[libraries]` blocks).

Files touched:
- `src/main/resources/cms/processors/add-script.js`
- `build.gradle`
- `gradle/libs.versions.toml`

## Test plan
- [x] `./gradlew build` passes locally
- [ ] CI green