### PR TITLE
Migrate to lib-asset #54

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     include xplibs.context
     include xplibs.admin
 
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
+
     include libs.lib.thymeleaf
 
     include 'com.google.auth:google-auth-library-oauth2-http:1.47.0'

--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -1,5 +1,6 @@
 const libs = {
     portal: require('/lib/xp/portal'),
+    asset: require('/lib/enonic/asset'),
     thymeleaf: require('/lib/thymeleaf')
 };
 
@@ -17,7 +18,7 @@ exports.responseProcessor = function (req, res) {
             configID: siteConfig["configId"],
             triggerID: "__googlesearch-trigger",
             tokenServiceUrl: libs.portal.serviceUrl({service: 'token'}),
-            styleSrc: libs.portal.assetUrl({path: "/css/googlesearch.css"}),
+            styleSrc: libs.asset.assetUrl({path: "/css/googlesearch.css"}),
             inputPlaceholder: siteConfig["inputPlaceholder"] || 'Search here...',
             location: siteConfig["location"],
         };
@@ -57,7 +58,7 @@ function getImageUrl(siteConfig) {
         imageUrl = libs.portal.attachmentUrl({id: imageContent, download: false});
     }
     if (!imageUrl) {
-        imageUrl = libs.portal.assetUrl({path: "/img/stars.svg"})
+        imageUrl = libs.asset.assetUrl({path: "/img/stars.svg"})
     }
     return imageUrl;
 }

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -2,3 +2,5 @@ kind: "Site"
 processors:
   - name: "add-script"
     order: 10
+apis:
+  - "asset"


### PR DESCRIPTION
Closes #54

`portal.assetUrl` is `@deprecated` in lib-portal. This PR replaces both call sites in `cms/processors/add-script.js` with `lib-asset`. The processor runs in a `Site` context, which is one of the contexts lib-asset supports (vs. lib-static, needed only for admin extensions / id providers / Universal APIs — none of which this app has).

## Changes

- `build.gradle` — `include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"`
- `src/main/resources/cms/site.yaml` — added `apis: ["asset"]` so the Universal Asset API is mounted on the Site context
- `src/main/resources/cms/processors/add-script.js`:
  - Added `asset: require('/lib/enonic/asset')`
  - Replaced `libs.portal.assetUrl({path: "/css/googlesearch.css"})` → `libs.asset.assetUrl(...)`
  - Replaced `libs.portal.assetUrl({path: "/img/stars.svg"})` → `libs.asset.assetUrl(...)`

The `/lib/xp/portal` import stays — `getSiteConfig`, `serviceUrl`, and `attachmentUrl` are still in use.

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean
- [x] Bundled jar contains `apis/asset/` and `lib/enonic/asset/`
- [x] In an XP 8 runtime, the app bundle reaches ACTIVE without errors
- [x] With a Site applying this app, the lib-asset URL pattern `/site/<project>/<branch>/<site>/_/<app>:asset/<fingerprint>/<path>` returns HTTP 200 with the expected payload for both replaced paths:
  - `/css/googlesearch.css` → 1324 B `text/css`
  - `/img/stars.svg` → 1493 B `image/svg+xml`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)